### PR TITLE
Fix sending mail after deprecated functions removal

### DIFF
--- a/action.php
+++ b/action.php
@@ -252,7 +252,7 @@ class action_plugin_tokenbucketauth extends DokuWiki_Action_Plugin
 		{
 			// Prepare fields
 			$subject = sprintf($this->getLang('mailsubject'), $conf['title']);
-			$body    = $this->plugin_locale_xhtml('mailbody');
+			$body    = $this->locale_xhtml('mailbody');
 			$from    = $conf['mailfrom'];
 
 			// Do some replacements


### PR DESCRIPTION
Fixes "Call to undefined method action_plugin_tokenbucketauth::plugin_locale_xhtml() in lib/plugins/tokenbucketauth/action.php on line 255" on 2013-05-10 "Weatherwax"
